### PR TITLE
Fix docs for jazzy and cocoapods

### DIFF
--- a/Sources/ReducerHelpers.swift
+++ b/Sources/ReducerHelpers.swift
@@ -16,8 +16,8 @@
 ///   - return value of the wrapped reducer function when both `state` is not nil
 ///     AND `action` is of type `SpecificActionType`
 ///
-/// - parameter initialState: the initial `state` for the Reducer passed in
-/// - parameter reducer:      the reducer being wrapped
+/// - parameter initialState: the initial State for the Reducer passed in
+/// - parameter reducer:      the Reducer function being wrapped
 ///
 /// - returns: A reducer function
 public func Reducer<State, SpecificActionType>(
@@ -37,7 +37,7 @@ public func Reducer<State, SpecificActionType>(
 ///
 /// - parameter reducers: an array of `Reducer`s who takes and returns the same type of `State`
 ///
-/// - returns: A reducer function
+/// - returns: A Reducer function
 public func combineReducers<State>(
     _ reducers: [(State?, Any) -> State]) -> (State?, Any
     ) -> State {

--- a/Sources/Store.swift
+++ b/Sources/Store.swift
@@ -11,10 +11,10 @@ extension Store {
 
     /// Dispatches the given *Action* to the given *Store*
     ///
-    /// - parameter store:  A *Store*
-    /// - parameter action: an Action dispatched to the *Store*
+    /// - parameter store:  A Store
+    /// - parameter action: an Action dispatched to the Store
     ///
-    /// - returns: `Void`
+    /// - returns: Void
     public typealias Dispatcher = (_ store: Store, _ action: Action) -> Void
 
     /// It provides a third-party extension point between dispatching an action,
@@ -28,18 +28,18 @@ extension Store {
     ///
     /// When a Store's State changes, the Store will notify the change to all of its *Subscribers*.
     ///
-    /// - parameter store: A *Store*
+    /// - parameter store: A Store
     ///
-    /// - returns: `Void`
+    /// - returns: Void
     public typealias Subscriber = (_ store: Store) -> ()
 
 
     /// Returns a new *State* based on the given *State* and *Action*
     ///
-    /// - parameter state:  the current *State* of a *Store*
-    /// - parameter action: an Action dispatched to the *Store*
+    /// - parameter state:  the current State of a Store
+    /// - parameter action: an Action dispatched to the Store
     ///
-    /// - returns: A new *State*
+    /// - returns: A new State
     public typealias Reducer = (_ state: State?, _ action: Action) -> State
 }
 
@@ -64,10 +64,10 @@ public final class Store<State> {
 
     /// The `init` method for a *Store*
     ///
-    /// - parameter reducer:     A *Reducer* function
-    /// - parameter middlewares: An array of *Middlewares*
+    /// - parameter reducer:     A Reducer function
+    /// - parameter middlewares: An array of Middlewares
     ///
-    /// - returns: A *Store*
+    /// - returns: A Store
     public init(with reducer: @escaping Reducer, middlewares: [Middleware] = []) {
         self.state = reducer(nil, InitialAction())
 
@@ -83,7 +83,7 @@ public final class Store<State> {
 
     /// Dispatches an *Action* to a *Store*'s *Reducer(s)*
     ///
-    /// - parameter action: An *Action*
+    /// - parameter action: An Action
     public func dispatch(_ action: Action) {
         dispatcher(self, action)
     }
@@ -91,7 +91,7 @@ public final class Store<State> {
 
     /// Subcribes a *Subscriber* to the changes of a *Store*'s *State*
     ///
-    /// - parameter subscriber: An *Subscriber* function
+    /// - parameter subscriber: A Subscriber function
     public final func subscribe(with subscriber: @escaping Subscriber) {
         subscribers.append(subscriber)
         subscriber(self)
@@ -103,10 +103,10 @@ extension Store {
 
     /// Combines *Middlewares* with a *Reducer*
     ///
-    /// - parameter middlewares: An array of *Middlewares*
-    /// - parameter reducer:     A *Reducer* function
+    /// - parameter middlewares: An array of Middlewares
+    /// - parameter reducer:     A Reducer function
     ///
-    /// - returns: A *Dispatcher* built with the default dispatcher and the given *Middlewares*
+    /// - returns: A Dispatcher built with the default dispatcher and the given Middlewares
     public static func combine(middlewares: [Middleware], with reducer: @escaping Reducer) -> Dispatcher {
         return self.combine(
             middlewares: middlewares,
@@ -116,10 +116,10 @@ extension Store {
 
     /// Combines *Middlewares* with a *Reducer*
     ///
-    /// - parameter middlewares: An array of *Middlewares*
-    /// - parameter dispatcher:  A *Dispatcher*
+    /// - parameter middlewares: An array of Middlewares
+    /// - parameter dispatcher:  A Dispatcher
     ///
-    /// - returns: A *Dispatcher* with the given dispatcher and the *Middlewares*
+    /// - returns: A Dispatcher with the given dispatcher and the Middlewares
     public static func combine(middlewares: [Middleware], with dispatcher: @escaping Dispatcher) -> Dispatcher {
         return middlewares
             .reversed()
@@ -136,9 +136,9 @@ extension Store {
     /// It will use the given *Reducer* to reduce new states and
     /// also notify subscirbers the new states.
     ///
-    /// - parameter reducer: A *Reducer* function
+    /// - parameter reducer: A Reducer function
     ///
-    /// - returns: A *Dispatcher*
+    /// - returns: A Dispatcher
     public static func defaultDispatcher(with reducer: @escaping Reducer) -> Dispatcher {
         return { (store: Store, action: Action) in
             store.state = reducer(store.state, action)

--- a/TDRedux.swift.podspec
+++ b/TDRedux.swift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "TDRedux.swift"
-  s.version      = "1.4.2"
+  s.version      = "1.4.3"
   s.summary      = "Yet another Redux written in Swift"
 
   s.description  = <<-DESC


### PR DESCRIPTION
Things in `**` were missing if they are in `parameter` or a `returns`,
e.g.

```
A *Reducer* function
```

will be rendered as:

> A function
