### PR TITLE
UpdateSubscriber don't care about state or store at all

### DIFF
--- a/Sources/Store+Dispatch.swift
+++ b/Sources/Store+Dispatch.swift
@@ -8,21 +8,6 @@
 
 extension Store {
 
-    /// Dispatches the given *Action* to its binded *Store*
-    ///
-    /// - parameter action: An Action dispatched to the Store
-    ///
-    /// - returns: Void
-    public typealias Dispatch = (_ action: Action) -> ()
-
-    /// Async actions which will call the dispatch function
-    ///
-    /// - parameter dispatch: a Dispatch function
-    ///
-    /// - returns: Void
-    public typealias AsyncAction = (_ dispath: @escaping Store.Dispatch) -> ()
-
-
     /// Dispatches *AsyncActions*
     ///
     /// - parameter action: An AsyncAction

--- a/Sources/Store+Subscribe.swift
+++ b/Sources/Store+Subscribe.swift
@@ -15,6 +15,8 @@ extension Store {
     /// - returns: Void
     public typealias StateSubscriber = (_ state: State) -> ()
 
+    public typealias UpdateSubscriber = () -> ()
+
     /// Subcribes a *StateSubscriber* (takes a *State* rather than a *Store*)
     /// to the changes of a *Store*'s *State*
     ///
@@ -22,6 +24,12 @@ extension Store {
     public func subscribe(with subscriber: @escaping StateSubscriber) {
         self.subscribe { store in
             subscriber(store.state)
+        }
+    }
+
+    public func subscribe(with subscriber: @escaping UpdateSubscriber) {
+        self.subscribe { (store: Store) in
+            subscriber()
         }
     }
 

--- a/Sources/Store+Subscribe.swift
+++ b/Sources/Store+Subscribe.swift
@@ -15,8 +15,6 @@ extension Store {
     /// - returns: Void
     public typealias StateSubscriber = (_ state: State) -> ()
 
-    public typealias UpdateSubscriber = () -> ()
-
     /// Subcribes a *StateSubscriber* (takes a *State* rather than a *Store*)
     /// to the changes of a *Store*'s *State*
     ///
@@ -26,6 +24,9 @@ extension Store {
             subscriber(store.state)
         }
     }
+
+    /// Gets called every time when the *State* of a *Store* changes
+    public typealias UpdateSubscriber = () -> ()
 
     public func subscribe(with subscriber: @escaping UpdateSubscriber) {
         self.subscribe { (store: Store) in

--- a/Sources/Store+Subscribe.swift
+++ b/Sources/Store+Subscribe.swift
@@ -18,6 +18,11 @@ extension Store {
         }
     }
 
+
+    /// The given *UpdateSubscriber* will be called
+    /// when the *State* of a *Store* changes
+    ///
+    /// - parameter subscriber: An UpdateSubscriber
     public func subscribe(with subscriber: @escaping UpdateSubscriber) {
         self.subscribe { (store: Store) in
             subscriber()

--- a/Sources/Store+Subscribe.swift
+++ b/Sources/Store+Subscribe.swift
@@ -12,7 +12,7 @@ extension Store {
     /// to the changes of a *Store*'s *State*
     ///
     /// - parameter subscriber: A StateSubscriber function
-    public func subscribe(with subscriber: @escaping StateSubscriber) {
+    public final func subscribe(with subscriber: @escaping StateSubscriber) {
         self.subscribe { store in
             subscriber(store.state)
         }
@@ -23,7 +23,7 @@ extension Store {
     /// when the *State* of a *Store* changes
     ///
     /// - parameter subscriber: An UpdateSubscriber
-    public func subscribe(with subscriber: @escaping UpdateSubscriber) {
+    public final func subscribe(with subscriber: @escaping UpdateSubscriber) {
         self.subscribe { (store: Store) in
             subscriber()
         }
@@ -35,7 +35,7 @@ extension Store {
     ///
     /// - parameter converter:  A function converts State to SpecificState
     /// - parameter subscriber: A SpecificStateSubscriber function
-    public func subscribe<SpecificState>(
+    public final func subscribe<SpecificState>(
         withConverter converter: @escaping (State) -> SpecificState,
         subscriber: @escaping (SpecificState) -> ()
     ) {

--- a/Sources/Store+Subscribe.swift
+++ b/Sources/Store+Subscribe.swift
@@ -8,13 +8,6 @@
 
 extension Store {
 
-    /// Subscribe to changes of a *Store*'s *State*
-    ///
-    /// - parameter state:  A State
-    ///
-    /// - returns: Void
-    public typealias StateSubscriber = (_ state: State) -> ()
-
     /// Subcribes a *StateSubscriber* (takes a *State* rather than a *Store*)
     /// to the changes of a *Store*'s *State*
     ///
@@ -24,9 +17,6 @@ extension Store {
             subscriber(store.state)
         }
     }
-
-    /// Gets called every time when the *State* of a *Store* changes
-    public typealias UpdateSubscriber = () -> ()
 
     public func subscribe(with subscriber: @escaping UpdateSubscriber) {
         self.subscribe { (store: Store) in

--- a/Sources/Store+Subscribe.swift
+++ b/Sources/Store+Subscribe.swift
@@ -24,7 +24,7 @@ extension Store {
     ///
     /// - parameter subscriber: An UpdateSubscriber
     public final func subscribe(with subscriber: @escaping UpdateSubscriber) {
-        self.subscribe { (store: Store) in
+        self.subscribe { (_: Store) in
             subscriber()
         }
     }

--- a/Sources/Store.swift
+++ b/Sources/Store.swift
@@ -6,43 +6,6 @@
 //  Copyright © 2016 nicktd. All rights reserved.
 //
 
-// MARK: - Types
-extension Store {
-
-    /// Dispatches the given *Action* to the given *Store*
-    ///
-    /// - parameter store:  A Store
-    /// - parameter action: an Action dispatched to the Store
-    ///
-    /// - returns: Void
-    public typealias Dispatcher = (_ store: Store, _ action: Action) -> Void
-
-    /// It provides a third-party extension point between dispatching an action,
-    /// and the moment it reaches the reducer.
-    public typealias Middleware = (@escaping Dispatcher) -> Dispatcher
-
-    /// Subscribes to changes of a *Store*'s *State*
-    ///
-    /// It can subscribe to a *Store* by calling `store.subscribe`.
-    ///
-    /// When a Store's State changes, the Store will notify the change to all of its *Subscribers*.
-    ///
-    /// - parameter store: A Store
-    ///
-    /// - returns: Void
-    public typealias Subscriber = (_ store: Store) -> ()
-
-    /// Returns a new *State* based on the given *State* and *Action*
-    ///
-    /// - parameter state:  the current State of a Store
-    /// - parameter action: an Action dispatched to the Store
-    ///
-    /// - returns: A new State
-    public typealias Reducer = (_ state: State?, _ action: Action) -> State
-}
-
-// MARK: - Store
-
 /// Holds a *State* in its `state`.
 ///
 /// You can

--- a/Sources/Store.swift
+++ b/Sources/Store.swift
@@ -20,7 +20,7 @@ public final class Store<State> {
     /// An array of *Subscribers*
     public final var subscribers = [Subscriber]()
 
-    private var dispatcher: Dispatcher
+    private final var dispatcher: Dispatcher
 
     /// The `init` method for a *Store*
     ///
@@ -43,7 +43,7 @@ public final class Store<State> {
     /// Dispatches an *Action* to a *Store*'s *Reducer(s)*
     ///
     /// - parameter action: An Action
-    public func dispatch(_ action: Action) {
+    public final func dispatch(_ action: Action) {
         dispatcher(self, action)
     }
 

--- a/Sources/Types.swift
+++ b/Sources/Types.swift
@@ -1,0 +1,76 @@
+//
+//  Types.swift
+//  TDRedux
+//
+//  Created by Nicholas Tian on 21/10/2016.
+//  Copyright © 2016 nicktd. All rights reserved.
+//
+
+// MARK: - Reducer
+extension Store {
+
+    /// Returns a new *State* based on the given *State* and *Action*
+    ///
+    /// - parameter state:  the current State of a Store
+    /// - parameter action: an Action dispatched to the Store
+    ///
+    /// - returns: A new State
+    public typealias Reducer = (_ state: State?, _ action: Action) -> State
+}
+
+// MARK: - Subscribers
+extension Store {
+
+    /// Subscribes to changes of a *Store*'s *State*
+    ///
+    /// It can subscribe to a *Store* by calling `store.subscribe`.
+    ///
+    /// When a Store's State changes, the Store will notify the change to all of its *Subscribers*.
+    ///
+    /// - parameter store: A Store
+    ///
+    /// - returns: Void
+    public typealias Subscriber = (_ store: Store) -> ()
+
+    /// Subscribe to changes of a *Store*'s *State*
+    ///
+    /// - parameter state:  A State
+    ///
+    /// - returns: Void
+    public typealias StateSubscriber = (_ state: State) -> ()
+
+
+    /// Gets called every time when the *State* of a *Store* changes
+    public typealias UpdateSubscriber = () -> ()
+}
+
+// MARK: - Dispatcher, Dispatch, Middleware and AsyncAction
+extension Store {
+
+    /// Dispatches the given *Action* to the given *Store*
+    ///
+    /// - parameter store:  A Store
+    /// - parameter action: an Action dispatched to the Store
+    ///
+    /// - returns: Void
+    public typealias Dispatcher = (_ store: Store, _ action: Action) -> Void
+
+
+    /// It provides a third-party extension point between dispatching an action,
+    /// and the moment it reaches the reducer.
+    public typealias Middleware = (@escaping Dispatcher) -> Dispatcher
+
+    /// Dispatches the given *Action* to its binded *Store*
+    ///
+    /// - parameter action: An Action dispatched to the Store
+    ///
+    /// - returns: Void
+    public typealias Dispatch = (_ action: Action) -> ()
+
+    /// Async actions can call the dispatch function
+    ///
+    /// - parameter dispatch: a Dispatch function
+    ///
+    /// - returns: Void
+    public typealias AsyncAction = (_ dispath: @escaping Store.Dispatch) -> ()
+}

--- a/Sources/Types.swift
+++ b/Sources/Types.swift
@@ -60,9 +60,9 @@ extension Store {
     /// and the moment it reaches the reducer.
     public typealias Middleware = (@escaping Dispatcher) -> Dispatcher
 
-    /// Dispatches the given *Action* to its binded *Store*
+    /// Dispatches the given *Action* to the binded *Store*
     ///
-    /// - parameter action: An Action dispatched to the Store
+    /// - parameter action: An Action will be dispatched to the binded Store
     ///
     /// - returns: Void
     public typealias Dispatch = (_ action: Action) -> ()

--- a/TDRedux.xcodeproj/project.pbxproj
+++ b/TDRedux.xcodeproj/project.pbxproj
@@ -59,6 +59,9 @@
 		75A244C81DB8D3C10005BE0F /* Store+Dispatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CFED2D31DB8A5750035F962 /* Store+Dispatch.swift */; };
 		75A244C91DB8D3C20005BE0F /* Store+Dispatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CFED2D31DB8A5750035F962 /* Store+Dispatch.swift */; };
 		75A244D51DB9F4EE0005BE0F /* Types.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75A244D41DB9F4EE0005BE0F /* Types.swift */; };
+		75A244D61DB9F99F0005BE0F /* Types.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75A244D41DB9F4EE0005BE0F /* Types.swift */; };
+		75A244D71DB9F9A00005BE0F /* Types.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75A244D41DB9F4EE0005BE0F /* Types.swift */; };
+		75A244D81DB9F9A10005BE0F /* Types.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75A244D41DB9F4EE0005BE0F /* Types.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -674,6 +677,7 @@
 				75A244C91DB8D3C20005BE0F /* Store+Dispatch.swift in Sources */,
 				7511D6951D97E84D008016CF /* Action.swift in Sources */,
 				7511D6961D97E84D008016CF /* Store.swift in Sources */,
+				75A244D81DB9F9A10005BE0F /* Types.swift in Sources */,
 				6C9AFBAF1DB5A4FD00592817 /* Store+Subscribe.swift in Sources */,
 				7511D6971D97E84D008016CF /* ReducerHelpers.swift in Sources */,
 			);
@@ -686,6 +690,7 @@
 				75A244C81DB8D3C10005BE0F /* Store+Dispatch.swift in Sources */,
 				7511D6921D97E847008016CF /* Action.swift in Sources */,
 				7511D6931D97E847008016CF /* Store.swift in Sources */,
+				75A244D71DB9F9A00005BE0F /* Types.swift in Sources */,
 				6C9AFBAE1DB5A4FD00592817 /* Store+Subscribe.swift in Sources */,
 				7511D6941D97E847008016CF /* ReducerHelpers.swift in Sources */,
 			);
@@ -698,6 +703,7 @@
 				75A244C71DB8D3C00005BE0F /* Store+Dispatch.swift in Sources */,
 				7511D68F1D97E83F008016CF /* Action.swift in Sources */,
 				7511D6901D97E83F008016CF /* Store.swift in Sources */,
+				75A244D61DB9F99F0005BE0F /* Types.swift in Sources */,
 				6C9AFBAD1DB5A4FD00592817 /* Store+Subscribe.swift in Sources */,
 				7511D6911D97E83F008016CF /* ReducerHelpers.swift in Sources */,
 			);

--- a/TDRedux.xcodeproj/project.pbxproj
+++ b/TDRedux.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		75A244C71DB8D3C00005BE0F /* Store+Dispatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CFED2D31DB8A5750035F962 /* Store+Dispatch.swift */; };
 		75A244C81DB8D3C10005BE0F /* Store+Dispatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CFED2D31DB8A5750035F962 /* Store+Dispatch.swift */; };
 		75A244C91DB8D3C20005BE0F /* Store+Dispatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CFED2D31DB8A5750035F962 /* Store+Dispatch.swift */; };
+		75A244D51DB9F4EE0005BE0F /* Types.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75A244D41DB9F4EE0005BE0F /* Types.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -88,6 +89,7 @@
 		753785DC1D9F2EDE004703E0 /* CombineReducersSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CombineReducersSpec.swift; sourceTree = "<group>"; };
 		753785E01D9FDF9B004703E0 /* MiddlewareSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MiddlewareSpec.swift; sourceTree = "<group>"; };
 		759134181DB605A1008AEF41 /* SubscribeExtensionSpecs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubscribeExtensionSpecs.swift; sourceTree = "<group>"; };
+		75A244D41DB9F4EE0005BE0F /* Types.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Types.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -193,6 +195,7 @@
 			isa = PBXGroup;
 			children = (
 				7511D6391D964B03008016CF /* Action.swift */,
+				75A244D41DB9F4EE0005BE0F /* Types.swift */,
 				7511D6361D964A3C008016CF /* Store.swift */,
 				6C9AFBAB1DB5A4FD00592817 /* Store+Subscribe.swift */,
 				6CFED2D31DB8A5750035F962 /* Store+Dispatch.swift */,
@@ -645,6 +648,7 @@
 				6CFED2D41DB8A5750035F962 /* Store+Dispatch.swift in Sources */,
 				7511D6371D964A3C008016CF /* Store.swift in Sources */,
 				7511D63C1D964BAA008016CF /* ReducerHelpers.swift in Sources */,
+				75A244D51DB9F4EE0005BE0F /* Types.swift in Sources */,
 				6C9AFBAC1DB5A4FD00592817 /* Store+Subscribe.swift in Sources */,
 				7511D63A1D964B03008016CF /* Action.swift in Sources */,
 			);

--- a/Tests/DispatchExtensionSpecs.swift
+++ b/Tests/DispatchExtensionSpecs.swift
@@ -37,7 +37,7 @@ class DispatchExtensionSpecs: QuickSpec {
                             "post 2",
                             "post 3",
                             ]),
-                        timeout: 0.1
+                        timeout: 0.15
                     )
                 }
             }
@@ -55,7 +55,7 @@ class DispatchExtensionSpecs: QuickSpec {
                     expect(store.state.error).to(beNil())
                     expect(store.state.error).toNotEventually(
                         beNil(),
-                        timeout: 0.1
+                        timeout: 0.15
                     )
                 }
             }

--- a/Tests/SubscribeExtensionSpecs.swift
+++ b/Tests/SubscribeExtensionSpecs.swift
@@ -60,6 +60,28 @@ class SubscribeExtensionSpecs: QuickSpec {
                     }
                 }
             }
+
+            context("when subscribed to a store's state") {
+                var called: Bool!
+
+                beforeEach {
+                    called = false
+                    store.subscribe {
+                        called = true
+                    }
+                }
+
+                context("when the store's state changed") {
+                    beforeEach {
+                        store.dispatch(ToDoActions.addToDo(title: "go buy me milk"))
+                    }
+
+                    it("gets the change") {
+                        expect(called).to(beTrue())
+                    }
+                }
+            }
+
         }
     }
 }


### PR DESCRIPTION
- Now you can subscribe to changes but pass no Subscriber
- Move typealiases in Store into `Types.swift`
- Mark all funcs in Store as `final`
