### PR TITLE
Remove final

### DIFF
--- a/Sources/Action.swift
+++ b/Sources/Action.swift
@@ -9,7 +9,7 @@
 /// An *Action* describes what happen**ed**
 /// while it may carry some data, e.g.
 /// `AddTodo(text: "buy milk")` or `ToggleTodo(atIndex: 1)`
-public typealias Action = Any
+public protocol Action { }
 
 /// The `InitialAction` is the action a *Store* will dispatch
 /// while initializing so that the *Store* can get its initial

--- a/Sources/Store+Subscribe.swift
+++ b/Sources/Store+Subscribe.swift
@@ -12,7 +12,7 @@ extension Store {
     /// to the changes of a *Store*'s *State*
     ///
     /// - parameter subscriber: A StateSubscriber function
-    public final func subscribe(with subscriber: @escaping StateSubscriber) {
+    public func subscribe(with subscriber: @escaping StateSubscriber) {
         self.subscribe { store in
             subscriber(store.state)
         }
@@ -23,7 +23,7 @@ extension Store {
     /// when the *State* of a *Store* changes
     ///
     /// - parameter subscriber: An UpdateSubscriber
-    public final func subscribe(with subscriber: @escaping UpdateSubscriber) {
+    public func subscribe(with subscriber: @escaping UpdateSubscriber) {
         self.subscribe { (_: Store) in
             subscriber()
         }
@@ -35,7 +35,7 @@ extension Store {
     ///
     /// - parameter converter:  A function converts State to SpecificState
     /// - parameter subscriber: A SpecificStateSubscriber function
-    public final func subscribe<SpecificState>(
+    public func subscribe<SpecificState>(
         withConverter converter: @escaping (State) -> SpecificState,
         subscriber: @escaping (SpecificState) -> ()
     ) {

--- a/Sources/Store.swift
+++ b/Sources/Store.swift
@@ -12,15 +12,15 @@
 ///  - create a `Store` with a *Reducer*
 ///  - dispatch *Actions* to change a *Store*'s *State*
 ///  - subscribe to changes happens to the *State* of a *Store* using *Subscribers*
-public final class Store<State> {
+public class Store<State> {
 
     /// the entire internal state of an application
-    public fileprivate(set) final var state: State
+    public fileprivate(set) var state: State
 
     /// An array of *Subscribers*
-    public final var subscribers = [Subscriber]()
+    public var subscribers = [Subscriber]()
 
-    private final var dispatcher: Dispatcher
+    private var dispatcher: Dispatcher
 
     /// The `init` method for a *Store*
     ///
@@ -43,14 +43,14 @@ public final class Store<State> {
     /// Dispatches an *Action* to a *Store*'s *Reducer(s)*
     ///
     /// - parameter action: An Action
-    public final func dispatch(_ action: Action) {
+    public func dispatch(_ action: Action) {
         dispatcher(self, action)
     }
 
     /// Subcribes a *Subscriber* to the changes of a *Store*'s *State*
     ///
     /// - parameter subscriber: A Subscriber function
-    public final func subscribe(with subscriber: @escaping Subscriber) {
+    public func subscribe(with subscriber: @escaping Subscriber) {
         subscribers.append(subscriber)
         subscriber(self)
     }

--- a/TDRedux.xcodeproj/project.pbxproj
+++ b/TDRedux.xcodeproj/project.pbxproj
@@ -73,7 +73,7 @@
 		6C74E5891D9DF79300F9742C /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Checkouts/Quick/build/Debug/Quick.framework; sourceTree = "<group>"; };
 		6C74E58C1D9DF79A00F9742C /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = "Carthage/Checkouts/Nimble/build/Debug-appletvos/Nimble.framework"; sourceTree = "<group>"; };
 		6C74E58D1D9DF79A00F9742C /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = "Carthage/Checkouts/Quick/build/Debug-appletvos/Quick.framework"; sourceTree = "<group>"; };
-		6C9AFBAB1DB5A4FD00592817 /* Store+Subscribe.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Store+Subscribe.swift"; sourceTree = "<group>"; };
+		6C9AFBAB1DB5A4FD00592817 /* Store+Subscribe.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = "Store+Subscribe.swift"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		6CFED2CE1DB8A25B0035F962 /* DispatchExtensionSpecs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DispatchExtensionSpecs.swift; sourceTree = "<group>"; };
 		6CFED2D31DB8A5750035F962 /* Store+Dispatch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Store+Dispatch.swift"; sourceTree = "<group>"; };
 		7511D61C1D964A1D008016CF /* TDRedux.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TDRedux.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -81,7 +81,7 @@
 		7511D6201D964A1D008016CF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		7511D6251D964A1D008016CF /* TDReduxTests-iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "TDReduxTests-iOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7511D62C1D964A1D008016CF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		7511D6361D964A3C008016CF /* Store.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Store.swift; sourceTree = "<group>"; };
+		7511D6361D964A3C008016CF /* Store.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Store.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		7511D6391D964B03008016CF /* Action.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Action.swift; sourceTree = "<group>"; };
 		7511D63B1D964BAA008016CF /* ReducerHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReducerHelpers.swift; sourceTree = "<group>"; };
 		7511D64F1D97CDCC008016CF /* TDRedux.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TDRedux.framework; sourceTree = BUILT_PRODUCTS_DIR; };

--- a/Tests/DispatchExtensionSpecs.swift
+++ b/Tests/DispatchExtensionSpecs.swift
@@ -108,8 +108,8 @@ private struct State {
     let error: String?
 }
 
-private enum Actions {
-    enum FetchPosts {
+private enum Actions: TDRedux.Action {
+    enum FetchPosts: TDRedux.Action {
         case start
         case success(posts: [String])
         case failed(error: String)

--- a/Tests/SubscribeExtensionSpecs.swift
+++ b/Tests/SubscribeExtensionSpecs.swift
@@ -96,7 +96,7 @@ private let reducer = Reducer(initialState: ToDoState.initial) {
     }
 }
 
-private enum ToDoActions {
+private enum ToDoActions: TDRedux.Action {
     case addToDo(title: String)
     case filter(with: Filter)
 }


### PR DESCRIPTION
- Everything is `final` by default after [SE-0117](https://github.com/apple/swift-evolution/blob/master/proposals/0117-non-public-subclassable-by-default.md)
- Make Action a protocol rather than a typealias of Any
  - Otherwise it could dispatch AsyncActions or Action types don't actually
    need to comform to Action
